### PR TITLE
Fix export hardware

### DIFF
--- a/scripts/export_hardware.tcl
+++ b/scripts/export_hardware.tcl
@@ -13,8 +13,8 @@
 # get the directory where this script resides
 set thisDir [file dirname [info script]]
 
-set TOP_PROJECT_NAME "zynq_bd_wrapper"
-
+set TOPLEVEL_NAME "zynq_bd_wrapper"
+set PROJECT_NAME "zynq"
 #for now, keeping this as zynq_bd_wrapper since the existing project referenced it
 set EXPORTED_SDK_NAME "zynq_bd_wrapper"
 
@@ -33,13 +33,15 @@ puts "  BUILD_WORKSPACE: $BUILD_WORKSPACE"
 puts "          IP_BASE: $IP_BASE"
 
 # Create project
-open_project [file normalize "$BUILD_WORKSPACE/zynq/zynq.xpr"]
+open_project [file normalize "$BUILD_WORKSPACE/$PROJECT_NAME/$PROJECT_NAME.xpr"]
 
 #export to sdk - standard location
-file mkdir [file normalize "$BUILD_WORKSPACE/zynq/zynq.sdk"]
-file copy -force [file normalize "$BUILD_WORKSPACE/zynq/zynq.runs/impl_1/$TOP_PROJECT_NAME.sysdef"] [file normalize "$BUILD_WORKSPACE/zynq/zynq.sdk/$TOP_PROJECT_NAME.hdf"]
+file mkdir [file normalize "$BUILD_WORKSPACE/$PROJECT_NAME/$PROJECT_NAME.sdk"]
+write_hwdef -force -file [file normalize $BUILD_WORKSPACE/$PROJECT_NAME/$PROJECT_NAME.runs/synth_1/$TOPLEVEL_NAME.hwdef]
+write_sysdef -force -hwdef [file normalize $BUILD_WORKSPACE/$PROJECT_NAME/$PROJECT_NAME.runs/synth_1/$TOPLEVEL_NAME.hwdef] -bitfile [file normalize $BUILD_WORKSPACE/$PROJECT_NAME/$PROJECT_NAME.runs/impl_1/$TOPLEVEL_NAME.bit] -file [file normalize $BUILD_WORKSPACE/$PROJECT_NAME/$PROJECT_NAME.runs/impl_1/$TOPLEVEL_NAME.sysdef]
+file copy -force [file normalize "$BUILD_WORKSPACE/zynq/zynq.runs/impl_1/$TOPLEVEL_NAME.sysdef"] [file normalize "$BUILD_WORKSPACE/zynq/zynq.sdk/$TOPLEVEL_NAME.hdf"]
 
 #export to sdk - alternate location for version control
-file mkdir [file normalize "$PROJECT_BASE/artifacts/$EXPORTED_SDK_NAME.sdk"]
-file copy -force [file normalize "$BUILD_WORKSPACE/zynq/zynq.runs/impl_1/$TOP_PROJECT_NAME.sysdef"] [file normalize "$PROJECT_BASE/artifacts/$EXPORTED_SDK_NAME.sdk/$EXPORTED_SDK_NAME.hdf"]
+#file mkdir [file normalize "$PROJECT_BASE/artifacts/$EXPORTED_SDK_NAME.sdk"]
+#file copy -force [file normalize "$BUILD_WORKSPACE/zynq/zynq.runs/impl_1/$TOPLEVEL_NAME.sysdef"] [file normalize "$PROJECT_BASE/artifacts/$EXPORTED_SDK_NAME.sdk/$EXPORTED_SDK_NAME.hdf"]
 puts "Hardware exported!"

--- a/scripts/setup_trenz_breakout.tcl
+++ b/scripts/setup_trenz_breakout.tcl
@@ -138,7 +138,6 @@ add_files -fileset constrs_1 -norecurse [glob $PROJECT_BASE/src/breakout/*.xdc]
 set_property synth_checkpoint_mode None [get_files  "$BUILD_WORKSPACE/zynq/zynq.srcs/sources_1/bd/zynq_bd/zynq_bd.bd"]
 
 puts "Setup of the Trenz Board complete!"
-puts "Now building our crap:"
 
 #source $thisDir/connect_gpio_to_vata_ports.tcl
 


### PR DESCRIPTION
This fixes a problem with using a PS and the OOC compile where the ps7_init info is not included in the export_hardware information given to the sdk. 

Fix found at https://forums.xilinx.com/t5/Embedded-Development-Tools/Cannot-Export-Hardware-Hardware-handoff-file-sysdef-does-not/td-p/539953 