### PR TITLE
Fixing dumb typo

### DIFF
--- a/src/py/silayer/python/__init__.py
+++ b/src/py/silayer/python/__init__.py
@@ -1,1 +1,2 @@
 from . import client, data_recvr, cfg_reg, raw2hdf
+from .client import Client

--- a/src/py/silayer/python/raw2hdf.py
+++ b/src/py/silayer/python/raw2hdf.py
@@ -293,7 +293,7 @@ class DataPackets(object):
     ]
     ## _hdf5_top_fields:
     ##      Top-level data that is common to all asic's,
-   with a single value per event.
+    ##      with a single value per event.
     _hdf5_top_fields = [
         "packet_size",
         "header_size",


### PR DESCRIPTION
Also making `silayer.client.Client` importable from `silayer`