### PR TITLE
Attempting to make data size explicit

### DIFF
--- a/src/py/silayer/python/raw2hdf.py
+++ b/src/py/silayer/python/raw2hdf.py
@@ -13,12 +13,15 @@ class DataSz:
     """
     Stupid thing to keep track of data sizes in bytes.
     """
-
     u8 = 1
     u16 = 2
     u32 = 4
     u64 = 8
-
+    ## Data types. Try and force lengths to be what we want.
+    to_type = {u8: np.dtype(f'<u{u8}'),
+               u16: np.dtype(f'<u{u16}'),
+               u32: np.dtype(f'<u{u32}'),
+               u64: np.dtype(f'<u{u64}')}
 
 def byte2bits(byte, nbits=8):
     """
@@ -370,15 +373,21 @@ class DataPackets(object):
         """
         sz = (self.n_asic, self.n_packet)
         ##self.time = np.zeros(self.n_packet, dtype=np.uint64)
-        self.packet_size = np.zeros(self.n_packet, dtype=np.uint16)
-        self.header_size = np.zeros(self.n_packet, dtype=np.uint8)
-        self.packet_flags = np.zeros(self.n_packet, dtype=np.uint16)
-        self.event_type = np.zeros(self.n_packet, dtype=np.uint16)
-        self.event_counter = np.zeros(self.n_packet, dtype=np.uint32)
-        self.real_time_counter = np.zeros(self.n_packet, dtype=np.uint64)
-        self.live_time_counter = np.zeros(self.n_packet, dtype=np.uint64)
-        self.event_ids = np.zeros(sz, dtype=np.uint32)
-        self.event_times = np.zeros(sz, dtype=np.uint64)
+
+        u8 = DataSz.to_type[DataSz.u8]
+        u16 = DataSz.to_type[DataSz.u16]
+        u32 = DataSz.to_type[DataSz.u16]
+        u64 = DataSz.to_type[DataSz.u64]
+
+        self.packet_size = np.zeros(self.n_packet, dtype=u16)
+        self.header_size = np.zeros(self.n_packet, dtype=u8)
+        self.packet_flags = np.zeros(self.n_packet, dtype=u16)
+        self.event_type = np.zeros(self.n_packet, dtype=u16)
+        self.event_counter = np.zeros(self.n_packet, dtype=u32)
+        self.real_time_counter = np.zeros(self.n_packet, dtype=u64)
+        self.live_time_counter = np.zeros(self.n_packet, dtype=u64)
+        self.event_ids = np.zeros(sz, dtype=u32)
+        self.event_times = np.zeros(sz, dtype=u64)
         self.start_bits = np.zeros(sz, dtype=np.bool)
         self.stop_bits = np.zeros(sz, dtype=np.bool)
         self.trigger_bits = np.zeros(sz, dtype=np.bool)
@@ -387,9 +396,9 @@ class DataPackets(object):
         self.dummy_status = np.zeros(sz, dtype=np.bool)
         self.channel_status = np.zeros(sz + (AsicPacket.N_CHANNEL,), dtype=np.bool)
         self.cm_status = np.zeros(sz, dtype=np.bool)
-        self.cm_data = np.zeros(sz, dtype=np.uint16)
-        self.dummy_data = np.zeros(sz, dtype=np.uint16)
-        self.data = np.zeros(sz + (AsicPacket.N_CHANNEL,), dtype=np.uint16)
+        self.cm_data = np.zeros(sz, dtype=u16)
+        self.dummy_data = np.zeros(sz, dtype=u16)
+        self.data = np.zeros(sz + (AsicPacket.N_CHANNEL,), dtype=u16)
 
     def write_hdf5(self, fname):
         """


### PR DESCRIPTION
It looks like there's an issue where np.uint64 does
not default to a datatype with a max value compatible
with the timers on some computers. This is an issue
when allocating arrays in preparation for writing the
hdf file.

Anyways, hopefully this works