### PR TITLE
Adding trigger enable mask on VATA register 21

### DIFF
--- a/cores/vata_460p3/component.xml
+++ b/cores/vata_460p3/component.xml
@@ -282,7 +282,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>39c65ede</spirit:value>
+            <spirit:value>530cdf60</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -298,7 +298,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>39c65ede</spirit:value>
+            <spirit:value>530cdf60</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -347,19 +347,6 @@
         </spirit:wire>
       </spirit:port>
       <spirit:port>
-        <spirit:name>trigger_ena</spirit:name>
-        <spirit:wire>
-          <spirit:direction>in</spirit:direction>
-          <spirit:wireTypeDefs>
-            <spirit:wireTypeDef>
-              <spirit:typeName>std_logic</spirit:typeName>
-              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
-              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
-            </spirit:wireTypeDef>
-          </spirit:wireTypeDefs>
-        </spirit:wire>
-      </spirit:port>
-      <spirit:port>
         <spirit:name>fast_or_trigger</spirit:name>
         <spirit:wire>
           <spirit:direction>in</spirit:direction>
@@ -373,7 +360,7 @@
         </spirit:wire>
       </spirit:port>
       <spirit:port>
-        <spirit:name>trigger_ena_force</spirit:name>
+        <spirit:name>force_trigger</spirit:name>
         <spirit:wire>
           <spirit:direction>in</spirit:direction>
           <spirit:wireTypeDefs>
@@ -771,6 +758,23 @@
           <spirit:direction>out</spirit:direction>
           <spirit:vector>
             <spirit:left spirit:format="long">3</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic_vector</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>trigger_ack_timeout_out</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">31</spirit:left>
             <spirit:right spirit:format="long">0</spirit:right>
           </spirit:vector>
           <spirit:wireTypeDefs>
@@ -1196,7 +1200,7 @@
       <spirit:file>
         <spirit:name>src/vata_460p3_axi_interface_v3_0.vhd</spirit:name>
         <spirit:fileType>vhdlSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_4d9e5235</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_4c878602</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
     <spirit:fileSet>
@@ -1304,12 +1308,12 @@
       </xilinx:taxonomies>
       <xilinx:displayName>vata_460p3_axi_interface_v3_0</xilinx:displayName>
       <xilinx:definitionSource>package_project</xilinx:definitionSource>
-      <xilinx:coreRevision>19</xilinx:coreRevision>
+      <xilinx:coreRevision>22</xilinx:coreRevision>
       <xilinx:upgrades>
         <xilinx:canUpgradeFrom>nasa.gov:user:vata_460p3_axi_interface_v2_0:1.0</xilinx:canUpgradeFrom>
         <xilinx:canUpgradeFrom>nasa.gov:user:vata_460p3_axi_interface:2.0</xilinx:canUpgradeFrom>
       </xilinx:upgrades>
-      <xilinx:coreCreationDateTime>2020-03-03T18:04:37Z</xilinx:coreCreationDateTime>
+      <xilinx:coreCreationDateTime>2020-03-04T17:23:24Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
         <xilinx:tag xilinx:name="nopcore"/>
         <xilinx:tag xilinx:name="ui.data.coregen.dd@145fbe1a_ARCHIVE_LOCATION">c:/Users/aschoenw/Documents/Projects/Hardware/FPGA/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
@@ -2291,14 +2295,50 @@
         <xilinx:tag xilinx:name="ui.data.coregen.dd@dfb12a2_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.dd@76314155_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.dd@3948830c_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@337a3d16_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7c2ae38a_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1a85a940_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@45d63e13_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3e252c41_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5fabff62_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7417c910_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@ff32ecb_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5ab2169c_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@24d72ec9_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@22b8c025_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4a3602cc_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3915cb99_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@49b266a1_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4cd8e74e_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@34fe48a1_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2461cf10_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@30002efb_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@61671a51_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3a45619_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3af66f3_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@662500e5_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@bffbec7_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@49084e24_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@36623649_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1ab35f63_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@6634a08a_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4d5ad445_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@341eb50f_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@161326a8_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5bd0bc5_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@43471678_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@34c95ae5_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@398226bb_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7dd4649_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5abc5238_ARCHIVE_LOCATION">/local/data/puff/sgriffi4/xilinx/lucas/ComPair-tracker-FPGA/cores/vata_460p3</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2018.3</xilinx:xilinxVersion>
       <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="cf2f49f5"/>
       <xilinx:checksum xilinx:scope="memoryMaps" xilinx:value="871c369d"/>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="f1ed8072"/>
-      <xilinx:checksum xilinx:scope="ports" xilinx:value="449c6eae"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="6d9ba92c"/>
+      <xilinx:checksum xilinx:scope="ports" xilinx:value="2d04b5af"/>
       <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="f5d49b29"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="f8c82e76"/>
     </xilinx:packagingInfo>

--- a/cores/vata_460p3/src/stay_high_n_cycles.vhd
+++ b/cores/vata_460p3/src/stay_high_n_cycles.vhd
@@ -25,7 +25,8 @@ architecture arch_imp of stay_high_n_cycles is
     signal current_state : std_logic := IDLE;
     signal next_state : std_logic := IDLE;
 
-    constant COUNTER_MAX : unsigned(N_CYCLES_WIDTH-1 downto 0) := to_unsigned(N_CYCLES, N_CYCLES_WIDTH);
+    -- Save as N_CYCLES-1 to get the correct widths
+    constant COUNTER_MAX : unsigned(N_CYCLES_WIDTH-1 downto 0) := to_unsigned(N_CYCLES-1, N_CYCLES_WIDTH);
     signal counter : unsigned(N_CYCLES_WIDTH-1 downto 0) := (others => '0');
     signal counter_clr : std_logic := '0';
     signal counter_ena : std_logic := '0';

--- a/cores/vata_460p3/src/vata_460p3_axi_interface_v3_0.vhd
+++ b/cores/vata_460p3/src/vata_460p3_axi_interface_v3_0.vhd
@@ -15,36 +15,35 @@ entity vata_460p3_axi_interface_v3_0 is
     );
     port (
         -- Users to add ports here
-        trigger_ack           : in std_logic;
-        trigger_ena           : in std_logic;
-        fast_or_trigger       : in std_logic;
-        trigger_ena_force     : in std_logic;
+        trigger_ack             : in std_logic;
+        fast_or_trigger         : in std_logic;
+        force_trigger           : in std_logic;
         disable_fast_or_trigger : in std_logic;
-        FEE_hit               : out std_logic;
-        FEE_ready             : out std_logic;
-        FEE_busy              : out std_logic;
-        FEE_spare             : out std_logic;
-        event_id_latch        : in std_logic;
-        event_id_data         : in std_logic;
-        vata_s0               : out std_logic;
-        vata_s1               : out std_logic;
-        vata_s2               : out std_logic;
-        vata_s_latch          : out std_logic;
-        vata_i1               : out std_logic;
-        vata_i3               : out std_logic;
-        vata_i4               : out std_logic;
-        vata_o5               : in std_logic;
-        vata_o6               : in std_logic;
+        FEE_hit                 : out std_logic;
+        FEE_ready               : out std_logic;
+        FEE_busy                : out std_logic;
+        FEE_spare               : out std_logic;
+        event_id_latch          : in std_logic;
+        event_id_data           : in std_logic;
+        vata_s0                 : out std_logic;
+        vata_s1                 : out std_logic;
+        vata_s2                 : out std_logic;
+        vata_s_latch            : out std_logic;
+        vata_i1                 : out std_logic;
+        vata_i3                 : out std_logic;
+        vata_i4                 : out std_logic;
+        vata_o5                 : in std_logic;
+        vata_o6                 : in std_logic;
         -- data stream here:
-        data_tvalid           : out std_logic;
-        data_tlast            : out std_logic;
-        data_tready           : in std_logic;
-        data_tdata            : out std_logic_vector(31 downto 0);
+        data_tvalid             : out std_logic;
+        data_tlast              : out std_logic;
+        data_tready             : in std_logic;
+        data_tdata              : out std_logic_vector(31 downto 0);
         --
-        vss_shutdown_n        : out std_logic;
+        vss_shutdown_n          : out std_logic;
  
-        cald                  : out std_logic;
-        caldb                 : out std_logic;
+        cald                    : out std_logic;
+        caldb                   : out std_logic;
         -- Temporary debug ports
         state_out         : out std_logic_vector(7 downto 0);
         event_id_out      : out std_logic_vector(31 downto 0);
@@ -52,8 +51,8 @@ entity vata_460p3_axi_interface_v3_0 is
         abort_daq         : out std_logic;
         trigger_ack_timeout_counter : out std_logic_vector(31 downto 0);
         trigger_ack_timeout_state : out std_logic_vector(3 downto 0);
+        trigger_ack_timeout_out   : out std_logic_vector(31 downto 0);
         FEE_hit0_out : out std_logic;
-        --FEE_ready0_out : out std_logic;
 
         -- User ports ends
         -- Do not modify the ports beyond this line
@@ -98,6 +97,9 @@ architecture arch_imp of vata_460p3_axi_interface_v3_0 is
         HOLD_TIME           : out std_logic_vector(15 downto 0);
         POWER_CYCLE_TIMER   : out std_logic_vector(31 downto 0);
         TRIGGER_ACK_TIMEOUT : out std_logic_vector(31 downto 0);
+        --TRIGGER_ENA_MASK    : out std_logic_vector(3 downto 0);
+        FAST_OR_TRIGGER_ENA : out std_logic;
+        ACK_TRIGGER_ENA     : out std_logic;
         RUNNING_COUNTER     : in std_logic_vector(63 downto 0);
         LIVE_COUNTER        : in std_logic_vector(63 downto 0);
         EVENT_COUNTER       : in std_logic_vector(31 downto 0);
@@ -128,54 +130,54 @@ architecture arch_imp of vata_460p3_axi_interface_v3_0 is
 
     component vata_460p3_iface_fsm
         port (
-            clk_100MHz         : in std_logic; -- 10 ns
-            rst_n              : in std_logic;
-            trigger_ack        : in std_logic;
-            trigger_ena        : in std_logic;
-            fast_or_trigger    : in std_logic;
-            trigger_ena_force  : in std_logic;
+            clk_100MHz              : in std_logic; -- 10 ns
+            rst_n                   : in std_logic;
+            fast_or_trigger         : in std_logic;
+            trigger_ack             : in std_logic;
+            fast_or_trigger_ena     : in std_logic;
+            ack_trigger_ena         : in std_logic;
+            force_trigger           : in std_logic;
             disable_fast_or_trigger : in std_logic;
-            trigger_ack_timeout: in std_logic_vector(31 downto 0);
-            FEE_hit            : out std_logic;
-            FEE_ready          : out std_logic;
-            FEE_busy           : out std_logic;
-            FEE_spare          : out std_logic;
-            event_id_latch     : in std_logic;
-            event_id_data      : in std_logic;
-            get_config         : in std_logic;
-            set_config         : in std_logic;
-            int_cal_trigger    : in std_logic;
-            hold_time          : in std_logic_vector(15 downto 0);
-            vata_s0            : out std_logic;
-            vata_s1            : out std_logic;
-            vata_s2            : out std_logic;
-            vata_s_latch       : out std_logic;
-            vata_i1            : out std_logic;
-            vata_i3            : out std_logic;
-            vata_i4            : out std_logic;
-            vata_o5            : in std_logic;
-            vata_o6            : in std_logic;
-            cfg_reg_from_ps    : in std_logic_vector(519 downto 0);
-            cfg_reg_from_pl    : out std_logic_vector(519 downto 0);
-            data_tvalid        : out std_logic;
-            data_tlast         : out std_logic;
-            data_tready        : in std_logic;
-            data_tdata         : out std_logic_vector(31 downto 0);
-            cald               : out std_logic;
-            caldb              : out std_logic;
-            counter_rst        : in std_logic;
-            running_counter    : out std_logic_vector(63 downto 0);
-            live_counter       : out std_logic_vector(63 downto 0);
-            event_counter_rst  : in std_logic;
-            event_counter      : out std_logic_vector(31 downto 0);
+            trigger_ack_timeout     : in std_logic_vector(31 downto 0);
+            FEE_hit                 : out std_logic;
+            FEE_ready               : out std_logic;
+            FEE_busy                : out std_logic;
+            FEE_spare               : out std_logic;
+            event_id_latch          : in std_logic;
+            event_id_data           : in std_logic;
+            get_config              : in std_logic;
+            set_config              : in std_logic;
+            int_cal_trigger         : in std_logic;
+            hold_time               : in std_logic_vector(15 downto 0);
+            vata_s0                 : out std_logic;
+            vata_s1                 : out std_logic;
+            vata_s2                 : out std_logic;
+            vata_s_latch            : out std_logic;
+            vata_i1                 : out std_logic;
+            vata_i3                 : out std_logic;
+            vata_i4                 : out std_logic;
+            vata_o5                 : in std_logic;
+            vata_o6                 : in std_logic;
+            cfg_reg_from_ps         : in std_logic_vector(519 downto 0);
+            cfg_reg_from_pl         : out std_logic_vector(519 downto 0);
+            data_tvalid             : out std_logic;
+            data_tlast              : out std_logic;
+            data_tready             : in std_logic;
+            data_tdata              : out std_logic_vector(31 downto 0);
+            cald                    : out std_logic;
+            caldb                   : out std_logic;
+            counter_rst             : in std_logic;
+            running_counter         : out std_logic_vector(63 downto 0);
+            live_counter            : out std_logic_vector(63 downto 0);
+            event_counter_rst       : in std_logic;
+            event_counter           : out std_logic_vector(31 downto 0);
             -- DEBUG --
-            event_id_out_debug : out std_logic_vector(31 downto 0);
-            abort_daq_debug    : out std_logic;
-            trigger_acq_out       : out std_logic;
+            event_id_out_debug      : out std_logic_vector(31 downto 0);
+            abort_daq_debug         : out std_logic;
+            trigger_acq_out         : out std_logic;
             trigger_ack_timeout_counter : out std_logic_vector(31 downto 0);
-            trigger_ack_timeout_state : out std_logic_vector(3 downto 0);
+            trigger_ack_timeout_state   : out std_logic_vector(3 downto 0);
             FEE_hit0_out       : out std_logic;
-            --FEE_ready0_out     : out std_logic;
             state_out          : out std_logic_vector(7 downto 0));
         end component;
 
@@ -217,11 +219,14 @@ architecture arch_imp of vata_460p3_axi_interface_v3_0 is
     signal trigger_power_cycle   : std_logic := '0';
     signal power_cycle_timer     : std_logic_vector(31 downto 0);
     signal trigger_ack_timeout   : std_logic_vector(31 downto 0);
+    signal trigger_ena_mask      : std_logic_vector(3 downto 0);
     signal counter_rst           : std_logic := '0';
     signal running_counter       : std_logic_vector(63 downto 0);
     signal live_counter          : std_logic_vector(63 downto 0);
     signal event_counter_rst     : std_logic := '0';
     signal event_counter         : std_logic_vector(31 downto 0);
+    signal fast_or_trigger_ena   : std_logic := '0';
+    signal ack_trigger_ena       : std_logic := '0';
 begin
 
 -- Instantiation of Axi Bus Interface S00_AXI
@@ -236,6 +241,9 @@ vata_460p3_axi_interface_v3_0_S00_AXI_inst : vata_460p3_axi_interface_v3_0_S00_A
         HOLD_TIME           => hold_time,
         POWER_CYCLE_TIMER   => power_cycle_timer,
         TRIGGER_ACK_TIMEOUT => trigger_ack_timeout,
+        --TRIGGER_ENA_MASK    => trigger_ena_mask,
+        FAST_OR_TRIGGER_ENA => fast_or_trigger_ena,
+        ACK_TRIGGER_ENA     => ack_trigger_ena,
         RUNNING_COUNTER     => running_counter,
         LIVE_COUNTER        => live_counter,
         EVENT_COUNTER       => event_counter,
@@ -271,9 +279,10 @@ vata_460p3_axi_interface_v3_0_S00_AXI_inst : vata_460p3_axi_interface_v3_0_S00_A
             clk_100MHz          => s00_axi_aclk,
             rst_n               => s00_axi_aresetn,
             trigger_ack         => trigger_ack,
-            trigger_ena         => trigger_ena,
+            fast_or_trigger_ena => fast_or_trigger_ena,
+            ack_trigger_ena     => ack_trigger_ena,
             fast_or_trigger     => fast_or_trigger,
-            trigger_ena_force   => trigger_ena_force,
+            force_trigger       => force_trigger,
             disable_fast_or_trigger => disable_fast_or_trigger,
             trigger_ack_timeout => trigger_ack_timeout,
             FEE_hit           => FEE_hit,
@@ -349,6 +358,9 @@ vata_460p3_axi_interface_v3_0_S00_AXI_inst : vata_460p3_axi_interface_v3_0_S00_A
     trigger_power_cycle <= ctrl_triggers(3);
     counter_rst         <= ctrl_triggers(4);
     event_counter_rst   <= ctrl_triggers(5);
+
+    -- Debug
+    trigger_ack_timeout_out <= trigger_ack_timeout;
 
     -- User logic ends
 

--- a/cores/vata_460p3/src/vata_460p3_axi_interface_v3_0_S00_AXI.vhd
+++ b/cores/vata_460p3/src/vata_460p3_axi_interface_v3_0_S00_AXI.vhd
@@ -21,6 +21,9 @@ entity vata_460p3_axi_interface_v3_0_S00_AXI is
 		HOLD_TIME	        : out std_logic_vector(15 downto 0);
 		POWER_CYCLE_TIMER   : out std_logic_vector(31 downto 0);
         TRIGGER_ACK_TIMEOUT : out std_logic_vector(31 downto 0);
+        TRIGGER_ENA_MASK    : out std_logic_vector(3 downto 0);
+        FAST_OR_TRIGGER_ENA : out std_logic;
+        ACK_TRIGGER_ENA     : out std_logic;
         RUNNING_COUNTER     : in std_logic_vector(63 downto 0);
         LIVE_COUNTER        : in std_logic_vector(63 downto 0);
         EVENT_COUNTER       : in std_logic_vector(31 downto 0);
@@ -1194,10 +1197,13 @@ begin
     CONFIG_REG_FROM_PS(511 downto 480) <= slv_reg16;
     CONFIG_REG_FROM_PS(519 downto 512) <= slv_reg17(7 downto 0);
 
-    HOLD_TIME <= slv_reg18(15 downto 0);
-    POWER_CYCLE_TIMER <= slv_reg19;
+    HOLD_TIME           <= slv_reg18(15 downto 0);
+    POWER_CYCLE_TIMER   <= slv_reg19;
     TRIGGER_ACK_TIMEOUT <= slv_reg20;
-
+    --TRIGGER_ENA_MASK    <= slv_reg21(3 downto 0);
+    -- Trigger enable mask unpacking:
+    FAST_OR_TRIGGER_ENA <= slv_reg21(0);
+    ACK_TRIGGER_ENA     <= slv_reg21(1);
 
 	-- User logic ends
 

--- a/cores/vata_460p3/src/vata_460p3_iface_fsm.vhd
+++ b/cores/vata_460p3/src/vata_460p3_iface_fsm.vhd
@@ -7,10 +7,10 @@ entity vata_460p3_iface_fsm is
                 clk_100MHz            : in std_logic; -- 10 ns
                 rst_n                 : in std_logic;
                 trigger_ack           : in std_logic;
-                trigger_ena           : in std_logic;
-                --trigger_ena_ena       : in std_logic;
+                ack_trigger_ena       : in std_logic;
+                fast_or_trigger_ena   : in std_logic;
                 fast_or_trigger       : in std_logic;
-                trigger_ena_force     : in std_logic;
+                force_trigger         : in std_logic;
                 disable_fast_or_trigger : in std_logic; 
                 trigger_ack_timeout   : in std_logic_vector(31 downto 0);
                 FEE_hit               : out std_logic;
@@ -178,14 +178,15 @@ architecture arch_imp of vata_460p3_iface_fsm is
     signal shift_reg_right_1 : std_logic := '0';
     signal reg_clr           : std_logic := '0';
 
-    signal event_id_clr : std_logic := '0';
-    signal event_id_out : std_logic_vector(EVENT_ID_WIDTH-1 downto 0);
-    signal abort_daq : std_logic;
+    signal event_id_clr  : std_logic := '0';
+    signal event_id_out  : std_logic_vector(EVENT_ID_WIDTH-1 downto 0);
+    signal abort_daq     : std_logic := '0';
+    signal abort_daq_buf : std_logic;
 
     signal trigger_acq            : std_logic := '0';
 
-    -- FEE outputs, before going into `stay_high_n_cycles`
-    signal FEE_hit0 : std_logic := '0';
+    -- FEE outputs, before going into `stay_high_n_cycles` 
+    signal FEE_hit0     : std_logic := '0';
     signal FEE_busy_buf : std_logic;
 
     signal urunning_counter : unsigned(63 downto 0) := (others => '0');
@@ -216,15 +217,30 @@ begin
         port map (
             clk_100MHz          => clk_100MHz,
             rst_n               => rst_n,
-            trigger_ena         => fast_or_trigger,
+            -------------------------------------------------------------------------------------
+            -- Use `trigger_ena => fast_or_trigger` for only handling timeout with fast-or-triggers
+            -- (this makes the most sense for actual setup)
+            --trigger_ena         => fast_or_trigger,
+            -------------------------------------------------------------------------------------
+            -- Use `trigger_ena => trigger_acq` for testing with any triggers
+            -- (this makes sense for debugging):
+            trigger_ena         => trigger_acq,
+            -------------------------------------------------------------------------------------
             trigger_ack         => trigger_ack,
             trigger_ack_timeout => trigger_ack_timeout,
-            abort_daq           => abort_daq_debug,
+            abort_daq           => abort_daq_buf,
             counter_out         => trigger_ack_timeout_counter,
             state_out           => trigger_ack_timeout_state
     );
-    abort_daq <= '0';
+    ---------------------
+    -- ENABLE ABORT DAQ:
+    abort_daq <= abort_daq_buf;
+    -- DISABLE ABORT DAQ:
+    -- abort_daq <= '0';
+    ---------------------
+    abort_daq_debug <= abort_daq_buf;
 
+    -- Generate 50ns long pulse for FEE_hit
     fee_hit_stay_high : stay_high_n_cycles
         generic map (
             N_CYCLES_WIDTH => 4,
@@ -236,6 +252,7 @@ begin
             data_out => FEE_hit
         );
 
+    -- Generate 50ns long pulse for FEE_ready out of ~FEE_busy
     fee_ready_stay_high : stay_high_n_cycles
         generic map (
             N_CYCLES_WIDTH => 4,
@@ -265,7 +282,7 @@ begin
         end if;
     end process;
 
-    process (rst_n, current_state, trigger_ena, set_config, get_config, state_counter)
+    process (rst_n, current_state, trigger_acq, set_config, get_config, state_counter)
     begin
         state_counter_clr            <= '0';
         dec_reg_indx                 <= '0';
@@ -982,8 +999,9 @@ begin
     event_counter   <= std_logic_vector(uevent_counter);
     
     -- Trigger acquisition:
-    --trigger_acq <= (trigger_ena_force) or (trigger_ena_ena and trigger_ena);
-    trigger_acq <= (trigger_ena_force) or (fast_or_trigger and trigger_ena);
+    trigger_acq <= force_trigger or
+                   (fast_or_trigger and fast_or_trigger_ena) or
+                   (trigger_ack and ack_trigger_ena);
 
     -- DEBUG --
     state_out          <= current_state;

--- a/src/petalinux/si-layer/project-spec/meta-user/recipes-apps/vatactrl/files/vatactrl/include/vata_constants.hpp
+++ b/src/petalinux/si-layer/project-spec/meta-user/recipes-apps/vatactrl/files/vatactrl/include/vata_constants.hpp
@@ -14,21 +14,29 @@
 #define N_ASIC_PACKET   16                  // Each asic packet should be 16 x 32 bits.
 #define DATA_PACKET_HEADER_NBYTES       3   //  [N-DATA_TOT, TIME0, TIME1]
 
+// AXI register offsets
 #define CFG_REG_OFFSET                  1
 #define READ_CFG_REG_OFFSET             31
 #define HOLD_TIME_REG_OFFSET            18
 #define POWER_CYCLE_REG_OFFSET          19
 #define TRIGGER_ACK_TIMEOUT_REG_OFFSET  20
+#define TRIGGER_ENA_MASK_REG_OFFSET     21
 #define RUNNING_TIMER_OFFSET            48
 #define LIVE_TIMER_OFFSET               50
 #define EVENT_COUNT_OFFSET              52
 
+// AXI control register interpretation
 #define AXI0_CTRL_SET_CONF              0
 #define AXI0_CTRL_GET_CONF              1
 #define AXI0_CTRL_TRIGGER_INT_CAL       2
 #define AXI0_CTRL_POWER_CYCLE           3
 #define AXI0_CTRL_RST_COUNTERS          4
 #define AXI0_CTRL_RST_EV_COUNT          5
+
+// Trigger enable mask bit mapping
+#define TRIGGER_ENA_MASK_LEN            2 // Only 2 values at this point considered
+#define TRIGGER_ENA_BIT_FAST_OR_HIT     0
+#define TRIGGER_ENA_BIT_TRIGGER_ACK     1
 
 typedef uint8_t u8;
 typedef uint16_t u16;

--- a/src/petalinux/si-layer/project-spec/meta-user/recipes-apps/vatactrl/files/vatactrl/include/vata_ctrl.hpp
+++ b/src/petalinux/si-layer/project-spec/meta-user/recipes-apps/vatactrl/files/vatactrl/include/vata_ctrl.hpp
@@ -25,8 +25,11 @@ class VataCtrl {
         u32 get_hold_delay();
         int get_counters(u64 &running, u64 &live);
         int reset_counters();
-        int trigger_enable();
-        int trigger_disable();
+        int trigger_enable(int mask_bit);
+        int trigger_enable_all();
+        int trigger_disable(int mask_bit);
+        int trigger_disable_all();
+        u32 get_trigger_ena_mask();
         int set_trigger_ack_timeout(u32 ack_timeout);
         u32 get_trigger_ack_timeout();
         u32 get_event_count();

--- a/src/petalinux/si-layer/project-spec/meta-user/recipes-apps/vatactrl/files/vatactrl/src/vata_ctrl.cpp
+++ b/src/petalinux/si-layer/project-spec/meta-user/recipes-apps/vatactrl/files/vatactrl/src/vata_ctrl.cpp
@@ -200,20 +200,45 @@ int VataCtrl::reset_counters() {
     return 0;
 }
 
-// Enable trigger acceptance by the asic.
-int VataCtrl::trigger_enable() {
-    if (pgpio_trigger_ena == NULL)
-        this->mmap_gpio_trigger_ena();
-    pgpio_trigger_ena[0] = 1;
+// Return 0 if set.
+// Return 1 if called with illegal mask_bit
+int VataCtrl::trigger_enable(int mask_bit) {
+    if (paxi == NULL)
+        this->mmap_axi();
+    if (mask_bit >= TRIGGER_ENA_MASK_LEN)
+        return 1;
+    paxi[TRIGGER_ENA_MASK_REG_OFFSET] |= (1 << mask_bit);
+    return 0;
+}
+
+int VataCtrl::trigger_enable_all() {
+    if (paxi == NULL)
+        this->mmap_axi();
+    paxi[TRIGGER_ENA_MASK_REG_OFFSET] = 0xFFFFFFFF;
     return 0;
 }
 
 // Disable trigger acceptance by the asic.
-int VataCtrl::trigger_disable() {
-    if (pgpio_trigger_ena == NULL)
-        this->mmap_gpio_trigger_ena();
-    pgpio_trigger_ena[0] = 0;
+int VataCtrl::trigger_disable(int mask_bit) {
+    if (paxi == NULL)
+        this->mmap_axi();
+    if (mask_bit >= TRIGGER_ENA_MASK_LEN)
+        return 1;
+    paxi[TRIGGER_ENA_MASK_REG_OFFSET] &= ~((u32)(1 << mask_bit));
     return 0;
+}
+
+int VataCtrl::trigger_disable_all() {
+    if (paxi == NULL)
+        this->mmap_axi();
+    paxi[TRIGGER_ENA_MASK_REG_OFFSET] = 0;
+    return 0;
+}
+
+u32 VataCtrl::get_trigger_ena_mask() {
+    if (paxi == NULL)
+        this->mmap_axi();
+    return paxi[TRIGGER_ENA_MASK_REG_OFFSET];
 }
 
 // Set the trigger acknowledge timeout


### PR DESCRIPTION
This allows for enabling/disabling different trigger sources
independently.

Also updated vata_ctrl stuff to deal with different triggers.
Currently handles the fast_or trigger, and trigger-ack trigger.

Commit also contains minor fix to the stay_high_n_cycles module