### PR TITLE
Adding build scripts

### DIFF
--- a/src/petalinux/apps/Makefile
+++ b/src/petalinux/apps/Makefile
@@ -1,0 +1,19 @@
+
+BUILD = dbe_production
+SILAYER_IP = 192.168.1.69
+
+all: server
+
+server: ctrl
+	cd build-scripts && ./make-server $(SILAYER_IP)
+
+ctrl: lib
+	cd build-scripts && ./make-ctrl $(SILAYER_IP)
+
+lib: zynq-dirs
+	cd build-scripts && ./make-lib $(SILAYER_IP)
+
+zynq-dirs:
+	cd build-scripts && ./make-zynq-dirs $(BUILD) $(SILAYER_IP)
+
+.PHONY: zynq-dirs lib ctrl server

--- a/src/petalinux/apps/README.md
+++ b/src/petalinux/apps/README.md
@@ -6,3 +6,8 @@ processor (as opposed to being built by petalinux).
 This is housed under petalinux/, which seemed sort of reasonable, as
 this directory contains programs that will run on our petalinux
 system.
+
+This directory includes a makefile. If you edit the variables defined
+at the top of the makefile, there's a good chance typing "make" will
+result in copying things over and building on the zynq for you. Of course for
+this to work, you'll have to have built bsp_petalinux

--- a/src/petalinux/apps/build-scripts/README.md
+++ b/src/petalinux/apps/build-scripts/README.md
@@ -1,0 +1,4 @@
+This directory contains the scripts to help with building things on the zynq
+
+If you know how to run them you can do so directly from this directory.
+Using the ../Makefile is easier though.

--- a/src/petalinux/apps/build-scripts/make-ctrl
+++ b/src/petalinux/apps/build-scripts/make-ctrl
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then 
+    echo "Usage: $0 ZYNQ-IP-ADDR"
+    exit 1
+fi
+
+IP_ADDR=$1
+
+if ! ping -c 1 -w 1 $IP_ADDR 1>/dev/null; then
+    echo "Could not ping $IP_ADDR"
+    echo "Check SILAYER_IP in Makefile"
+    exit 2 
+fi
+
+CTRL_DIR=$(pwd)/../silayer-ctrl
+DEST_DIR=/home/root/zynq/src/
+
+ssh root@${IP_ADDR} "if [ ! -d ${DEST_DIR} ]; then mkdir -p ${DEST_DIR}; fi"
+scp -r ${CTRL_DIR} root@${IP_ADDR}:${DEST_DIR}
+ssh root@${IP_ADDR} "cd ${DEST_DIR}/silayer-ctrl && make && make install"
+
+## vim: set ts=4 sw=4 sts=4 et:

--- a/src/petalinux/apps/build-scripts/make-lib
+++ b/src/petalinux/apps/build-scripts/make-lib
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then 
+    echo "Usage: $0 ZYNQ-IP-ADDR"
+    exit 1
+fi
+
+IP_ADDR=$1
+
+if ! ping -c 1 -w 1 $IP_ADDR 1>/dev/null; then
+    echo "Could not ping $IP_ADDR"
+    echo "Check SILAYER_IP in Makefile"
+    exit 2 
+fi
+
+LIB_DIR=$(pwd)/../silayer-lib
+DEST_DIR=/home/root/zynq/src/
+
+ssh root@${IP_ADDR} "if [ ! -d ${DEST_DIR} ]; then mkdir -p ${DEST_DIR}; fi"
+scp -r ${LIB_DIR} root@${IP_ADDR}:${DEST_DIR}
+ssh root@${IP_ADDR} "cd ${DEST_DIR}/silayer-lib && make && make install"
+
+## vim: set ts=4 sw=4 sts=4 et:

--- a/src/petalinux/apps/build-scripts/make-server
+++ b/src/petalinux/apps/build-scripts/make-server
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then 
+    echo "Usage: $0 ZYNQ-IP-ADDR"
+    exit 1
+fi
+
+IP_ADDR=$1
+
+if ! ping -c 1 -w 1 $IP_ADDR 1>/dev/null; then
+    echo "Could not ping $IP_ADDR"
+    echo "Check SILAYER_IP in Makefile"
+    exit 2 
+fi
+
+SERVER_DIR=$(pwd)/../silayer-server
+DEST_DIR=/home/root/zynq/src/
+
+ssh root@${IP_ADDR} "if [ ! -d ${DEST_DIR} ]; then mkdir -p ${DEST_DIR}; fi"
+scp -r ${SERVER_DIR} root@${IP_ADDR}:${DEST_DIR}
+ssh root@${IP_ADDR} "cd ${DEST_DIR}/silayer-server && make && make install"
+
+## vim: set ts=4 sw=4 sts=4 et:

--- a/src/petalinux/apps/build-scripts/make-zynq-dirs
+++ b/src/petalinux/apps/build-scripts/make-zynq-dirs
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+## This script scp's the xilinx bsp headers to the zynq. 
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Usage: $0 BUILD ZYNQ-IP-ADDR"
+    exit 1
+fi
+
+BUILD=$1
+IP_ADDR=$2
+
+if ! ping -c 1 -w 1 $IP_ADDR 1>/dev/null; then
+    echo "Could not ping $IP_ADDR"
+    echo "Check SILAYER_IP in Makefile"
+    exit 2 
+fi
+
+BSP_DIR=$(pwd)/../../../../work/$BUILD/zynq/zynq.sdk/bsp_petalinux/ps7_cortexa9_0/include/
+DEST_DIR=/home/root/zynq/include/bsp/
+ETC_DIR=/home/root/zynq/etc/
+
+ssh root@${IP_ADDR} "if [ ! -d ${DEST_DIR} ]; then mkdir -p ${DEST_DIR}; fi"
+scp ${BSP_DIR}/* root@${IP_ADDR}:${DEST_DIR}
+ssh root@${IP_ADDR} "if [ ! -d ${ETC_DIR} ]; then mkdir -p ${ETC_DIR}; fi"
+
+## vim: set ts=4 sw=4 sts=4 et:

--- a/src/petalinux/apps/silayer-ctrl/Makefile
+++ b/src/petalinux/apps/silayer-ctrl/Makefile
@@ -2,7 +2,7 @@ CC = g++
 
 ZYNQ_DIR = $(HOME)/zynq
 
-CXXFLAGS = -std=c++11 -Wall -I./include -I$(ZYNQ_DIR)/include
+CXXFLAGS = -std=c++11 -Wall -I./include -I$(ZYNQ_DIR)/include/bsp -I$(ZYNQ_DIR)/include
 LDFLAGS = -L$(ZYNQ_DIR)/lib -lsictrl
 
 TARGETS = calctrl dacctrl vatactrl

--- a/src/petalinux/apps/silayer-lib/Makefile
+++ b/src/petalinux/apps/silayer-lib/Makefile
@@ -5,7 +5,7 @@ OBJS = src/cal_ctrl.o src/dac_ctrl.o src/vata_ctrl.o
 
 ZYNQ_DIR = $(HOME)/zynq
 
-CXXFLAGS = -std=c++11 -Wall -I./include -I$(ZYNQ_DIR)/include
+CXXFLAGS = -std=c++11 -Wall -I./include -I $(ZYNQ_DIR)/include/bsp -I$(ZYNQ_DIR)/include
 
 
 all: $(TARGET)
@@ -27,7 +27,6 @@ src/dac_ctrl.o: src/dac_ctrl.cpp
 
 src/vata_ctrl.o: src/vata_ctrl.cpp
 	$(CC) $(CXXFLAGS) -o $@ -c $^ 
-
 
 clean:
 	$(RM) src/*.o *~

--- a/src/petalinux/apps/silayer-lib/include/vata_constants.hpp
+++ b/src/petalinux/apps/silayer-lib/include/vata_constants.hpp
@@ -29,9 +29,9 @@
 #define AXI0_CTRL_GET_CONF              1
 #define AXI0_CTRL_TRIGGER_INT_CAL       2
 #define AXI0_CTRL_POWER_CYCLE           3
-#define AXI0_CTRL_RST_COUNTERS          4
-#define AXI0_CTRL_RST_EV_COUNT          5
-#define AXI0_CTRL_FORCE_TRIGGER         6
+//#define AXI0_CTRL_RST_COUNTERS          4
+#define AXI0_CTRL_RST_EV_COUNT          4
+#define AXI0_CTRL_FORCE_TRIGGER         5
 
 // Trigger enable mask bit mapping
 #define TRIGGER_ENA_MASK_LEN            3 // Only 3 values at this point considered

--- a/src/petalinux/apps/silayer-lib/src/vata_ctrl.cpp
+++ b/src/petalinux/apps/silayer-lib/src/vata_ctrl.cpp
@@ -198,7 +198,8 @@ int VataCtrl::get_counters(u64 &running, u64 &live) {
 int VataCtrl::reset_counters() {
     if (paxi == NULL)
         this->mmap_axi();
-    paxi[0] = AXI0_CTRL_RST_COUNTERS;
+    //paxi[0] = AXI0_CTRL_RST_COUNTERS;
+    std::cout << "WARNING: RESET COUNTERS IS GOING AWAY! NO ACTION TAKEN" << std::endl;
     return 0;
 }
 

--- a/src/petalinux/apps/silayer-server/Makefile
+++ b/src/petalinux/apps/silayer-server/Makefile
@@ -1,7 +1,7 @@
 ##CXX_FLAGS = -std=c++11 -I$(HOME)/local/include -I$(HOME)/include -Wall
 ZYNQ = $(HOME)/zynq
 LOCAL = $(HOME)/local
-CXX_FLAGS = -std=c++11 -I$(LOCAL)/include -I$(ZYNQ)/include -I$(ZYNQ)/include/xil -Wall
+CXX_FLAGS = -std=c++11 -I$(LOCAL)/include -I$(ZYNQ)/include -I$(ZYNQ)/include/bsp -Wall
 TARGETS = silayer_server
 
 LD_FLAGS = -L$(ZYNQ)/lib -L$(LOCAL)/lib
@@ -24,5 +24,11 @@ silayer_server_main.o: silayer_server_main.cpp
 silayer_server: data_packet.o data_emitter.o silayer_server.o silayer_server_main.o
 	g++ -o $@ $(LD_FLAGS) $^ $(SERVER_LIBS) -pthread
 
+install: $(TARGETS)
+	install -d $(ZYNQ)/bin
+	install -m 755 silayer_server $(ZYNQ)/bin
+
 clean:
 	$(RM) *~ *.o
+
+.PHONY: clean


### PR DESCRIPTION
These scripts should automate the build and install process
on the zynq.

Ideally, you will run:
```bash
cd src/petalinux/apps && make
```
and everything will get scp'd over and built for you.

Some assembly still required:
* You will still need to build zmq, but that will be added soon.
* You will have to check src/petalinux/apps/Makefile that
  `BUILD` and `SILAYER_IP` are as you want them to be